### PR TITLE
Require phpunit 5.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "league/oauth2-client": "^2.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "*",
+        "phpunit/phpunit": "^5.0",
         "mockery/mockery": "*"
     },
     "autoload": {


### PR DESCRIPTION
PHPUnit 6 Drops Support for PHP 5.6.

ref: https://github.com/sebastianbergmann/phpunit/wiki/Release-Announcement-for-PHPUnit-6.0.0